### PR TITLE
CI: Disable rustfmt on Rust nightly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV components="rustfmt clippy"
 #### Base image for NIGHTLY
 FROM rustlang/rust:nightly AS cargo-base-nightly
 # WTF? clippy is broken in nightly
-ENV components="rustfmt"
+ENV components=""
 
 #### Common logic for base image
 FROM cargo-base-$channel AS cargo-build
@@ -18,7 +18,7 @@ WORKDIR /root/build
 
 RUN apt-get update && \
     apt-get install -y libacl1-dev
-RUN rustup component add $components
+RUN if test -n "$components"; then rustup component add $components; fi
 # Build Cargo dependencies for cache
 COPY Cargo.toml ./
 RUN mkdir src/ && \


### PR DESCRIPTION
This fixes the currently broken build.