### PR TITLE
Enable CI tests on pull requests and weekly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,18 @@
 name: Tests
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+  schedule:
+    # 16:18 UTC on Tuesdays
+    - cron: "18 16 * * tue"
+  repository_dispatch:
+    types: [tests]
+
 env:
   DOCKER_BUILDKIT: 1
-jobs:
 
+jobs:
   rust-nightly:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
* Pull requests from foreign repositories weren't being tested. :(
* Also test master branch on weekly schedule