### PR TITLE
Implement Debug trait for PosixACL

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ use acl_sys::{
     acl_t, acl_to_text, acl_valid, ACL_GROUP, ACL_GROUP_OBJ, ACL_MASK, ACL_OTHER, ACL_TYPE_ACCESS,
     ACL_UNDEFINED_TAG, ACL_USER, ACL_USER_OBJ,
 };
+use std::fmt;
 use std::os::raw::c_void;
 
 #[cfg(test)]
@@ -42,6 +43,13 @@ pub const ACL_RWX: u32 = ACL_READ | ACL_WRITE | ACL_EXECUTE;
 /// The ACL of a file.
 pub struct PosixACL {
     acl: acl_t,
+}
+
+/// Custom debug formatting, since output `PosixACL { acl: 0x7fd74c000ca8 }` is not very helpful.
+impl fmt::Debug for PosixACL {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PosixACL {{ \"{}\" }}", self.compact_text())
+    }
 }
 
 /** NB! Unix-only */
@@ -343,7 +351,7 @@ impl PosixACL {
     }
 
     fn compact_text(&self) -> String {
-        self.as_text().replace('\n', ",")
+        self.as_text().trim_end().replace('\n', ",")
     }
 
     /// Call the platform's validation function. Unfortunately it is not possible to provide

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ impl fmt::Debug for PosixACL {
     }
 }
 
-/** NB! Unix-only */
+/// NB! Unix-only
 fn path_to_cstring(path: &Path) -> CString {
     CString::new(path.as_os_str().as_bytes()).unwrap()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,11 @@ pub struct PosixACL {
 
 /// Custom debug formatting, since output `PosixACL { acl: 0x7fd74c000ca8 }` is not very helpful.
 impl fmt::Debug for PosixACL {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "PosixACL {{ \"{}\" }}", self.compact_text())
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Not really a tuple, but tuple formatting is compact.
+        fmt.debug_tuple("PosixACL")
+            .field(&self.compact_text().to_string())
+            .finish()
     }
 }
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -179,6 +179,6 @@ fn debug() {
 
     assert_eq!(
         format!("{:?}", acl),
-        "PosixACL { \"user::rw-,user:root:rw-,group::r--,group:root:r--,mask::rw-,other::---\" }"
+        "PosixACL(\"user::rw-,user:root:rw-,group::r--,group:root:r--,mask::rw-,other::---\")"
     );
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -119,12 +119,12 @@ fn equality() {
     let acl = PosixACL::new(0o751);
 
     // Not using assert_eq! because the debug trait is not implemented by PosixACL.
-    assert!(acl == acl);
-    assert!(acl == PosixACL::new(0o751));
-    assert!(acl != PosixACL::new(0o741));
+    assert_eq!(acl, acl);
+    assert_eq!(acl, PosixACL::new(0o751));
+    assert_ne!(acl, PosixACL::new(0o741));
 
     acl.remove(Mask);
-    assert!(acl != PosixACL::new(0o751));
+    assert_ne!(acl, PosixACL::new(0o751));
 }
 #[test]
 fn iterate() {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -59,7 +59,7 @@ fn validate_empty() {
     acl.fix_mask();
     assert_eq!(
         acl.validate().unwrap_err().as_str(),
-        "Invalid ACL: mask::---,"
+        "Invalid ACL: mask::---"
     );
 }
 #[test]
@@ -74,7 +74,7 @@ fn validate_ok() {
     acl.set(Group(0), ACL_READ);
     assert_eq!(
         acl.validate().unwrap_err().as_str(),
-        "Invalid ACL: user::rw-,user:root:r--,group::rw-,group:root:r--,other::---,"
+        "Invalid ACL: user::rw-,user:root:r--,group::rw-,group:root:r--,other::---"
     );
 
     acl.fix_mask();
@@ -166,5 +166,19 @@ fn iterate() {
                 perm: 0
             }
         ]
+    );
+}
+// Test debug formatting
+#[test]
+fn debug() {
+    // Cannot use `full_fixture()` because UID 99 is not portable
+    let mut acl = PosixACL::new(0o640);
+    acl.set(User(0), ACL_READ | ACL_WRITE);
+    acl.set(Group(0), ACL_READ);
+    acl.fix_mask();
+
+    assert_eq!(
+        format!("{:?}", acl),
+        "PosixACL { \"user::rw-,user:root:rw-,group::r--,group:root:r--,mask::rw-,other::---\" }"
     );
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -172,11 +172,6 @@ fn iterate() {
 // Test debug formatting
 #[test]
 fn debug() {
-    // Cannot use `full_fixture()` because UID 99 is not portable
-    // let mut acl = PosixACL::new(0o640);
-    // acl.set(User(0), ACL_READ | ACL_WRITE);
-    // acl.set(Group(0), ACL_READ);
-    // acl.fix_mask();
     let mut acl = full_fixture();
 
     assert_eq!(


### PR DESCRIPTION
* Custom debug formatting, since output `PosixACL { acl: 0x7fd74c000ca8 }` is not very helpful.
* Also improved output of ACL validation errors.
* Use  UID/GID 55555 in tests to avoid conflicts.
