### PR TITLE
Omit Mask ACL entry in constructor

### DIFF
--- a/src/acl.rs
+++ b/src/acl.rs
@@ -49,26 +49,25 @@ impl PartialEq for PosixACL {
 }
 
 impl PosixACL {
-    /// Convert a file mode ("chmod" number) into an ACL. This is the primary constructor.
-    /// Note that modes are usually expressed in Octal, e.g. `PosixACL::new(0o644)`
+    /// Convert a file mode ("chmod" number) into a "minimal" ACL. This is the primary constructor.
+    /// Note that modes are usually expressed in octal, e.g. `PosixACL::new(0o644)`
     ///
     /// This creates the minimal required entries. By the POSIX ACL spec, every valid ACL must
-    /// contain at least four entries: UserObj, GroupObj, Mask and Other.
+    /// contain at least three entries: UserObj, GroupObj and Other, corresponding to file mode bits.
     ///
-    /// Bits higher than 9 (e.g. SUID flag, etc) are ignored.
+    /// Input bits higher than 9 (e.g. SUID flag, etc) are ignored.
     ///
     /// ```
     /// use posix_acl::PosixACL;
     /// assert_eq!(
     ///     PosixACL::new(0o751).as_text(),
-    ///     "user::rwx\ngroup::r-x\nmask::r-x\nother::--x\n"
+    ///     "user::rwx\ngroup::r-x\nother::--x\n"
     /// );
     /// ```
     pub fn new(file_mode: u32) -> PosixACL {
         let mut acl = PosixACL::empty();
         acl.set(UserObj, (file_mode >> 6) & ACL_RWX);
         acl.set(GroupObj, (file_mode >> 3) & ACL_RWX);
-        acl.set(Mask, (file_mode >> 3) & ACL_RWX);
         acl.set(Other, file_mode & ACL_RWX);
         acl
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -36,10 +36,7 @@ fn test_file(dir: &TempDir, name: &str, mode: u32) -> PathBuf {
 #[test]
 fn new() {
     let acl = PosixACL::new(0o751);
-    assert_eq!(
-        acl.as_text(),
-        "user::rwx\ngroup::r-x\nmask::r-x\nother::--x\n"
-    );
+    assert_eq!(acl.as_text(), "user::rwx\ngroup::r-x\nother::--x\n");
     assert_eq!(acl.validate(), Ok(()));
 }
 #[test]
@@ -127,7 +124,6 @@ fn remove() {
 
     assert_eq!(acl.remove(GroupObj), Some(ACL_READ | ACL_EXECUTE));
     assert_eq!(acl.remove(Other), Some(0));
-    assert_eq!(acl.remove(Mask), Some(ACL_READ | ACL_EXECUTE));
 
     assert_eq!(acl.entries(), [])
 }
@@ -140,7 +136,7 @@ fn equality() {
     assert_eq!(acl, PosixACL::new(0o751));
     assert_ne!(acl, PosixACL::new(0o741));
 
-    acl.remove(Mask);
+    acl.remove(Other);
     assert_ne!(acl, PosixACL::new(0o751));
 }
 #[test]
@@ -228,13 +224,10 @@ fn read_file_with_no_acl() {
     let path = test_file(&dir, "test.file", 0o640);
 
     let mut acl = PosixACL::read_acl(&path).unwrap();
-    // On Linux, this is missing the "mask" entry
     assert_eq!(
         format!("{:?}", acl),
         "PosixACL(\"user::rw-,group::r--,other::---\")"
     );
-    // After calling fix_mask it's equal to `PosixACL::new()`
-    acl.fix_mask();
     assert_eq!(acl, PosixACL::new(0o640));
 }
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -223,7 +223,7 @@ fn read_file_with_no_acl() {
     let dir = tempdir().unwrap();
     let path = test_file(&dir, "test.file", 0o640);
 
-    let mut acl = PosixACL::read_acl(&path).unwrap();
+    let acl = PosixACL::read_acl(&path).unwrap();
     assert_eq!(
         format!("{:?}", acl),
         "PosixACL(\"user::rw-,group::r--,other::---\")"


### PR DESCRIPTION
The Mask entry is not required when ACL is "minimal", meaning it contains only the three chmod-related entries.