### PR TITLE
Ignore Clippy upper_case_acronyms lint

### DIFF
--- a/src/acl.rs
+++ b/src/acl.rs
@@ -22,6 +22,7 @@ use std::{fmt, mem};
 /// Implements a "mapping-like" interface where key is the `Qualifier` enum and value is `u32`
 /// containing permission bits.
 /// Using methods `get(qual) -> perms`, `set(qual, perms)`, `remove(qual)`.
+#[allow(clippy::upper_case_acronyms)]
 pub struct PosixACL {
     pub(crate) acl: acl_t,
 }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -73,6 +73,7 @@ impl Qualifier {
 
 /// Returned from [`PosixACL::entries()`](crate::PosixACL::entries).
 #[derive(Debug, PartialEq)]
+#[allow(clippy::upper_case_acronyms)]
 pub struct ACLEntry {
     pub qual: Qualifier,
     pub perm: u32,

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,7 @@ pub(crate) const FLAG_WRITE: u32 = 0x4000_0000;
 // Perhaps an overkill, I could have used io::Error instead.
 // But now that I wrote this, might as well keep it. :)
 #[derive(Debug)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum ACLError {
     /// Error reading or writing ACL.
     IoError(IoErrorDetail),

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -3,6 +3,7 @@ use crate::PosixACL;
 use acl_sys::{acl_entry_t, acl_get_entry, ACL_FIRST_ENTRY, ACL_NEXT_ENTRY};
 use std::ptr::null_mut;
 
+#[allow(clippy::upper_case_acronyms)]
 pub(crate) struct RawACLIterator<'a> {
     acl: &'a PosixACL,
     next: i32,


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/#upper_case_acronyms