### PR TITLE
Fix warnings from Clippy & GitHub JSON schema

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,8 @@ on:
     branches: [master]
   pull_request:
   schedule:
-    # 16:18 UTC on Tuesdays
-    - cron: "18 16 * * tue"
+    # 16:38 UTC on Tuesdays
+    - cron: "38 16 * * TUE"
   repository_dispatch:
     types: [tests]
 

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -151,7 +151,7 @@ impl PosixACL {
 
     /// Iterator of `acl_entry_t`, unsafe
     pub(crate) unsafe fn raw_iter(&self) -> RawACLIterator {
-        RawACLIterator::new(&self)
+        RawACLIterator::new(self)
     }
 
     /// Get all ACLEntry items. The POSIX ACL C API does not allow multiple parallel iterators so we


### PR DESCRIPTION
Clippy:

> this expression borrows a reference (`&acl::PosixACL`) that is immediately dereferenced by the compiler

GitHub `.github/workflows/tests.yml` schedule failed JSON schema regex validation.