### PR TITLE
Fix Clippy: derive Eq for Qualifier & ACLEntry + minor tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ fn main() {
 
 Release history
 ---------------
+##### UNRELEASED
+
+* `Qualifier` and `ACLEntry` now implement `Eq` (in addition to `PartialEq`) (#61)
+
 ##### 1.1.0 (2022-05-25)
 
 * Added `ACLError::as_io_error()` method to access the underlying `std::io::Error` instance (#57)

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -72,7 +72,7 @@ impl Qualifier {
 }
 
 /// Returned from [`PosixACL::entries()`](crate::PosixACL::entries).
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[allow(clippy::upper_case_acronyms)]
 pub struct ACLEntry {
     pub qual: Qualifier,

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -7,7 +7,7 @@ use acl_sys::{
 use std::ptr::null_mut;
 
 /// The subject of a permission grant.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Qualifier {
     /// Unrecognized/corrupt entries
     Undefined,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! ```
 //! use posix_acl::{PosixACL, Qualifier, ACL_READ, ACL_WRITE};
 //!
-//! # std::fs::File::create("/tmp/posix-acl-testfile");
+//! # std::fs::File::create("/tmp/posix-acl-testfile").unwrap();
 //! // Read ACL from file (if there is no ACL yet, the OS will synthesize one)
 //! let mut acl = PosixACL::read_acl("/tmp/posix-acl-testfile").unwrap();
 //!


### PR DESCRIPTION
Lint: https://rust-lang.github.io/rust-clippy/master/#derive_partial_eq_without_eq

Also added omitted `unwrap()` in doctest.