### PR TITLE
docs: add errors/panics sections, minor tweaks

### DIFF
--- a/src/acl.rs
+++ b/src/acl.rs
@@ -316,7 +316,7 @@ impl PosixACL {
     ///
     /// To avoid a memory leak, the `acl_t` must either:
     ///
-    /// - Be converted back to a `PosixACL` using `PosixACL::from_raw()`
+    /// - Be converted back to a `PosixACL` using [`PosixACL::from_raw()`]
     /// - Have `acl_free()` called on it
     //
     // Note: it's typically considered safe for Rust functions to leak resources (in this specific
@@ -333,10 +333,10 @@ impl PosixACL {
     ///
     /// # Safety
     ///
-    /// The `acl_t` must be a valid acl (not `(acl_t)NULL`) acl returned
-    /// either `PosixACL::into_raw` or another acl library function.
+    /// The `acl_t` must be a valid ACL (not `(acl_t)NULL`) acl returned
+    /// either [`PosixACL::into_raw()`] or another ACL library function.
     ///
-    /// Improper usage of this function may lead to memory problems (e.g.
+    /// Improper usage of this function may lead to memory unsafety (e.g.
     /// calling it twice on the same acl may lead to a double free).
     pub unsafe fn from_raw(acl: acl_t) -> Self {
         Self { acl }

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -95,7 +95,9 @@ impl PosixACL {
     /// # Errors
     /// * `ACLError::IoError`: Filesystem errors (file not found, permission denied, etc).
     ///
-    /// It is *NOT* an error if the provided path has no ACL; a minimal ACL will be returned.
+    /// <div class="warning">
+    /// It is NOT an error if the provided path has no ACL; a minimal ACL will be returned.
+    /// </div>
     pub fn read_acl<P: AsRef<Path>>(path: P) -> Result<PosixACL, ACLError> {
         Self::read_acl_flags(path.as_ref(), ACL_TYPE_ACCESS)
     }
@@ -112,8 +114,11 @@ impl PosixACL {
     ///
     /// # Errors
     /// * `ACLError::IoError`: Filesystem errors (file not found, permission denied, etc).
+    /// * Passing a non-directory path will fail with 'permission denied' error on Linux.
     ///
-    /// It is *NOT* an error if the provided path has no ACL; a minimal ACL will be returned.
+    /// <div class="warning">
+    /// It is NOT an error if the provided path has no ACL; an empty ACL will be returned.
+    /// </div>
     pub fn read_default_acl<P: AsRef<Path>>(path: P) -> Result<PosixACL, ACLError> {
         Self::read_acl_flags(path.as_ref(), ACL_TYPE_DEFAULT)
     }

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -54,7 +54,8 @@ impl PosixACL {
     /// Note that modes are usually expressed in octal, e.g. `PosixACL::new(0o644)`
     ///
     /// This creates the minimal required entries. By the POSIX ACL spec, every valid ACL must
-    /// contain at least three entries: UserObj, GroupObj and Other, corresponding to file mode bits.
+    /// contain at least three entries: `UserObj`, `GroupObj` and `Other`, corresponding to file
+    /// mode bits.
     ///
     /// Input bits higher than 9 (e.g. SUID flag, etc) are ignored.
     ///
@@ -90,6 +91,11 @@ impl PosixACL {
     /// use posix_acl::PosixACL;
     /// let acl = PosixACL::read_acl("/etc/shells").unwrap();
     /// ```
+    ///
+    /// # Errors
+    /// * `ACLError::IoError`: Filesystem errors (file not found, permission denied, etc).
+    ///
+    /// It is *NOT* an error if the provided path has no ACL; a minimal ACL will be returned.
     pub fn read_acl<P: AsRef<Path>>(path: P) -> Result<PosixACL, ACLError> {
         Self::read_acl_flags(path.as_ref(), ACL_TYPE_ACCESS)
     }
@@ -103,6 +109,11 @@ impl PosixACL {
     /// use posix_acl::PosixACL;
     /// let acl = PosixACL::read_default_acl("/tmp").unwrap();
     /// ```
+    ///
+    /// # Errors
+    /// * `ACLError::IoError`: Filesystem errors (file not found, permission denied, etc).
+    ///
+    /// It is *NOT* an error if the provided path has no ACL; a minimal ACL will be returned.
     pub fn read_default_acl<P: AsRef<Path>>(path: P) -> Result<PosixACL, ACLError> {
         Self::read_acl_flags(path.as_ref(), ACL_TYPE_DEFAULT)
     }
@@ -121,6 +132,11 @@ impl PosixACL {
     ///
     /// Note: this function takes mutable `self` because it automatically re-calculates the magic
     /// `Mask` entry.
+    ///
+    /// # Errors
+    /// * `ACLError::IoError`: Filesystem errors (file not found, permission denied, etc).
+    /// * `ACLError::ValidationError`: The ACL failed validation. See [`PosixACL::validate()`] for
+    ///    more information.
     pub fn write_acl<P: AsRef<Path>>(&mut self, path: P) -> Result<(), ACLError> {
         self.write_acl_flags(path.as_ref(), ACL_TYPE_ACCESS)
     }
@@ -133,6 +149,11 @@ impl PosixACL {
     ///
     /// Note: this function takes mutable `self` because it automatically re-calculates the magic
     /// `Mask` entry.
+    ///
+    /// # Errors
+    /// * `ACLError::IoError`: Filesystem errors (file not found, permission denied, etc).
+    /// * `ACLError::ValidationError`: The ACL failed validation. See [`PosixACL::validate()`] for
+    ///    more information.
     pub fn write_default_acl<P: AsRef<Path>>(&mut self, path: P) -> Result<(), ACLError> {
         self.write_acl_flags(path.as_ref(), ACL_TYPE_DEFAULT)
     }
@@ -154,7 +175,7 @@ impl PosixACL {
         RawACLIterator::new(self)
     }
 
-    /// Get all ACLEntry items. The POSIX ACL C API does not allow multiple parallel iterators so we
+    /// Get all `ACLEntry` items. The POSIX ACL C API does not allow multiple parallel iterators so we
     /// return a materialized vector just to be safe.
     pub fn entries(&self) -> Vec<ACLEntry> {
         unsafe { self.raw_iter() }
@@ -245,6 +266,11 @@ impl PosixACL {
     /// (`'\n'`).
     ///
     /// UID/GID are automatically resolved to names by the platform.
+    ///
+    /// # Panics
+    ///
+    /// When platform returns a string that is not valid UTF-8.
+    #[must_use]
     pub fn as_text(&self) -> String {
         let mut len: ssize_t = 0;
         let txt = AutoPtr(unsafe { acl_to_text(self.acl, &mut len) });
@@ -265,6 +291,9 @@ impl PosixACL {
     /// If you didn't take special care of the `Mask` entry, it may be necessary to call
     /// `fix_mask()` prior to `validate()`.
     ///
+    /// # Errors
+    /// * `ACLError::ValidationError`: The ACL failed validation.
+    ///
     /// Unfortunately it is not possible to provide detailed error reasons, but mainly it can be:
     /// * Required entries are missing (`UserObj`, `GroupObj`, `Mask` and `Other`).
     /// * ACL contains entries that are not unique.
@@ -282,8 +311,9 @@ impl PosixACL {
     ///
     /// To avoid a memory leak, the `acl_t` must either:
     ///
-    /// - Be converted back to a PosixACL using `PosixACL::from_raw`
-    /// - Have `acl_free` called on it
+    /// - Be converted back to a `PosixACL` using `PosixACL::from_raw()`
+    /// - Have `acl_free()` called on it
+    //
     // Note: it's typically considered safe for Rust functions to leak resources (in this specific
     // case, the function is analogous to the safe `Rc::into_raw` function in the standard library).
     // For more discussion on this, see [the nomicon](https://doc.rust-lang.org/nomicon/leaking.html).

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -43,7 +43,7 @@ impl Qualifier {
             _ => None,
         }
     }
-    /// Convert C type acl_entry_t to Rust Qualifier
+    /// Convert C type `acl_entry_t` to Rust Qualifier
     pub(crate) fn from_entry(entry: acl_entry_t) -> Qualifier {
         let tag_type = 0;
         let ret = unsafe { acl_get_tag_type(entry, &tag_type) };
@@ -61,7 +61,7 @@ impl Qualifier {
             }
         }
     }
-    /// Helper function for from_entry()
+    /// Helper function for `from_entry()`
     fn get_entry_uid(entry: acl_entry_t) -> u32 {
         unsafe {
             let uid = AutoPtr(acl_get_qualifier(entry) as *mut u32);
@@ -80,7 +80,7 @@ pub struct ACLEntry {
 }
 
 impl ACLEntry {
-    /// Convert C type acl_entry_t to Rust ACLEntry
+    /// Convert C type `acl_entry_t` to Rust `ACLEntry`
     pub(crate) fn from_entry(entry: acl_entry_t) -> ACLEntry {
         let perm;
         let mut permset: acl_permset_t = null_mut();

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,7 +15,7 @@ pub(crate) const FLAG_WRITE: u32 = 0x4000_0000;
 #[derive(Debug)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum ACLError {
-    /// Error reading or writing ACL.
+    /// Filesystem error while reading or writing ACL (file not found, permission denied, etc).
     IoError(IoErrorDetail),
     /// ACL is not valid and cannot be written.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,10 @@
 //! acl.write_acl("/tmp/posix-acl-testfile").unwrap();
 //! ```
 
+#![warn(clippy::doc_markdown)]
+#![warn(clippy::missing_errors_doc)]
+#![warn(clippy::missing_panics_doc)]
+
 mod acl;
 mod entry;
 mod error;


### PR DESCRIPTION
* Added separate Errors/Panics documentation section to functions where relevant.
* Added backticks to satisfy `clippy::doc_markdown` lint.
* Few minor docs tweaks.
* Enable relevant Clippy documentation lints.
