### PR TITLE
build: increase Minimum Supported Rust Version (MSRV) to 1.60

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "posix-acl"
 version = "1.1.0"
 edition = "2018"
-rust-version = "1.42.0"
+rust-version = "1.60.0"
 
 # Metadata
 authors = ["Marti Raudsepp <marti@juffo.org>"]

--- a/varia/Dockerfile.tests
+++ b/varia/Dockerfile.tests
@@ -12,7 +12,7 @@ FROM rustlang/rust:nightly AS cargo-base-nightly
 ENV components="" buildflags="--tests"
 
 #### Base image for MSRV
-FROM rust:1.42.0 AS cargo-base-msrv
+FROM rust:1.60.0 AS cargo-base-msrv
 # Don't build tests: dev-dependencies are incompatible with MSRV.
 ENV components="" buildflags=""
 


### PR DESCRIPTION
Needed to update `tempfile` dev-dependency.

It seems older Rust versions validate dev-dependencies with registry even if build does not need dev-dependencies. And that fails with error:

```
0.749     Updating crates.io index
33.93 error: failed to select a version for the requirement `rustix = "^0.38.21"`
33.93 candidate versions found which didn't match: 0.38.9, 0.38.8, 0.38.7, ...
33.93 location searched: crates.io index
33.93 required by package `tempfile v3.8.1`
33.93     ... which satisfies dependency `tempfile = "^3.8.1"` of package `posix-acl v1.1.0 (/root/build)`
```
