### PR TITLE
chore: disable Renovate Dockerfile updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "docker:disable"
   ]
 }


### PR DESCRIPTION
Pff, Renovate was too smart for the previous attempted work-around (#81). Just disable Renovate Dockerfile support, we don't need it anyway.