### PR TITLE
fix: resolve new 'elided lifetime' warning in Rust nightly

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -10,7 +10,7 @@ pub(crate) struct RawACLIterator<'a> {
 }
 
 impl<'a> RawACLIterator<'a> {
-    pub(crate) fn new(acl: &'a PosixACL) -> RawACLIterator {
+    pub(crate) fn new(acl: &'a PosixACL) -> RawACLIterator<'a> {
         RawACLIterator {
             acl,
             next: ACL_FIRST_ENTRY,


### PR DESCRIPTION
Fixes build warning in CI with Rust nightly:

```
error: elided lifetime has a name
  --> src/iter.rs:13:45
   |
12 | impl<'a> RawACLIterator<'a> {
   |      -- lifetime `'a` declared here
13 |     pub(crate) fn new(acl: &'a PosixACL) -> RawACLIterator {
   |                                             ^^^^^^^^^^^^^^ this elided lifetime gets resolved as `'a`
   |
   = note: `-D elided-named-lifetimes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(elided_named_lifetimes)]`
```