### PR TITLE
ci: improve testing & fix Clippy warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,9 +29,8 @@ jobs:
         run: docker run --rm posixacl-nightly cargo test --color=always
       # Run sanitizer checks. Only allowed on Rust nightly. https://github.com/japaric/rust-san
       # Cannot run sanitizers from Dockerfile, CAP_PTRACE is disallowed :(
-      # DISABLED TEMPORARILY due to https://github.com/rust-lang/rust/issues/111073
-      #- name: LeakSanitizer
-      #  run: docker run --rm --env RUSTFLAGS="-Z sanitizer=leak" posixacl-nightly cargo test --color=always
+      - name: LeakSanitizer
+        run: docker run --rm --env RUSTFLAGS="-Z sanitizer=leak" posixacl-nightly cargo test --color=always
       - name: AddressSanitizer
         # --tests to omit doc tests, doesn't play nice with AddressSanitizer
         run: docker run --rm --env RUSTFLAGS="-Z sanitizer=address" posixacl-nightly cargo test --tests --color=always
@@ -49,10 +48,8 @@ jobs:
             --tag=posixacl-stable
       - name: Test suite
         run: docker run --rm posixacl-stable cargo test --color=always
-      - name: cargo check
-        run: docker run --rm posixacl-stable cargo check --color=always
       - name: Clippy lints
-        run: docker run --rm posixacl-stable cargo clippy --color=always
+        run: docker run --rm posixacl-stable cargo clippy --color=always --all-targets --all-features -- -D warnings
       - name: rustfmt
         run: docker run --rm posixacl-stable cargo fmt -- --color=always --check
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,8 @@ jobs:
         run: docker run --rm posixacl-stable cargo fmt -- --color=always --check
 
   rust-msrv:
+    # FIXME disabled temporarily, needs MSRV bump
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -146,7 +146,7 @@ impl PosixACL {
     /// # Errors
     /// * `ACLError::IoError`: Filesystem errors (file not found, permission denied, etc).
     /// * `ACLError::ValidationError`: The ACL failed validation. See [`PosixACL::validate()`] for
-    ///    more information.
+    ///   more information.
     pub fn write_acl<P: AsRef<Path>>(&mut self, path: P) -> Result<(), ACLError> {
         self.write_acl_flags(path.as_ref(), ACL_TYPE_ACCESS)
     }
@@ -163,7 +163,7 @@ impl PosixACL {
     /// # Errors
     /// * `ACLError::IoError`: Filesystem errors (file not found, permission denied, etc).
     /// * `ACLError::ValidationError`: The ACL failed validation. See [`PosixACL::validate()`] for
-    ///    more information.
+    ///   more information.
     pub fn write_default_acl<P: AsRef<Path>>(&mut self, path: P) -> Result<(), ACLError> {
         self.write_acl_flags(path.as_ref(), ACL_TYPE_DEFAULT)
     }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -18,7 +18,7 @@ impl<'a> RawACLIterator<'a> {
     }
 }
 
-impl<'a> Iterator for RawACLIterator<'a> {
+impl Iterator for RawACLIterator<'_> {
     type Item = acl_entry_t;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -262,6 +262,7 @@ fn read_default_acl() {
     assert_eq!(format!("{:?}", acl), "PosixACL(\"\")");
 }
 /// Test different types accepted by AsRef<Path>
+#[allow(clippy::needless_borrows_for_generic_args)]
 #[test]
 fn path_types() {
     PosixACL::read_acl("/tmp").unwrap();


### PR DESCRIPTION
* Re-enable LeakSanitizer; Rust bug was fixed:
  * https://github.com/rust-lang/rust/issues/111073
* Run Clippy with `--all-targets --all-features`
* Remove useless `cargo check` (we do `cargo build` anyway)
* Fix new Clippy warnings
* Temporarily disable MSRV test job -- dependencies need MSRV bump first