### PR TITLE
chore: increase Minimum Supported Rust Version (MSRV) to 1.63

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,8 +54,6 @@ jobs:
         run: docker run --rm posixacl-stable cargo fmt -- --color=always --check
 
   rust-msrv:
-    # FIXME disabled temporarily, needs MSRV bump
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "posix-acl"
 version = "1.2.0"
 edition = "2018"
-rust-version = "1.60.0"
+rust-version = "1.63.0"
 
 # Metadata
 authors = ["Marti Raudsepp <marti@juffo.org>"]

--- a/varia/Dockerfile.tests
+++ b/varia/Dockerfile.tests
@@ -1,7 +1,7 @@
 # This Dockerfile is mostly for CI, see .github/workflows/tests.yml
 # Run with --build-arg=channel=stable OR --build-arg=channel=nightly (default)
 ARG rust=nightly
-ARG msrv=1.60.0
+ARG msrv=1.63.0
 
 # Using Dockerfile conditionals
 #### Base image for STABLE


### PR DESCRIPTION
The `libc` dependency no longer builds with MSRV 1.60.