### PR TITLE
chore: fix new Clippy warning

### DIFF
--- a/src/acl.rs
+++ b/src/acl.rs
@@ -181,7 +181,7 @@ impl PosixACL {
     }
 
     /// Iterator of `acl_entry_t`, unsafe
-    pub(crate) unsafe fn raw_iter(&self) -> RawACLIterator {
+    pub(crate) unsafe fn raw_iter(&self) -> RawACLIterator<'_> {
         RawACLIterator::new(self)
     }
 


### PR DESCRIPTION
```
error: lifetime flowing from input to output with different syntax can be confusing
   --> src/acl.rs:184:35
    |
184 |     pub(crate) unsafe fn raw_iter(&self) -> RawACLIterator {
    |                                   ^^^^^     -------------- the lifetime gets resolved as `'_`
    |                                   |
    |                                   this lifetime flows to the output
    |
    = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
184 |     pub(crate) unsafe fn raw_iter(&self) -> RawACLIterator<'_> {
    |                                                           ++++
```