### PR TITLE
Bump MSRV to 1.65

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "posix-acl"
 version = "1.2.0"
 edition = "2018"
-rust-version = "1.63.0"
+rust-version = "1.65.0"
 
 # Metadata
 authors = ["Marti Raudsepp <marti@juffo.org>"]

--- a/varia/Dockerfile.tests
+++ b/varia/Dockerfile.tests
@@ -1,7 +1,7 @@
 # This Dockerfile is mostly for CI, see .github/workflows/tests.yml
 # Run with --build-arg=channel=stable OR --build-arg=channel=nightly (default)
 ARG rust=nightly
-ARG msrv=1.63.0
+ARG msrv=1.65.0
 
 # Using Dockerfile conditionals
 #### Base image for STABLE


### PR DESCRIPTION
Fixes CI failure: https://github.com/intgr/posix-acl/actions/runs/24095439576/job/70295434071

Latest version of `libc 0.2.x` now requires Rust >=1.65: https://github.com/rust-lang/libc/releases/tag/0.2.184

It's easier to bump MSRV than pin an older version of `libc`; Rust 1.65 is still very old.